### PR TITLE
Update Iris Rev8 layout for C# work

### DIFF
--- a/current/iris_rev__8.layout.json
+++ b/current/iris_rev__8.layout.json
@@ -1,7 +1,24 @@
 {
   "name": "Iris Rev. 8",
   "vendorProductId": 3406856790,
-  "macros": ["", "", "", "", "", "", "", "", "", "", "", "", "", "", "", ""],
+  "macros": [
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    ""
+  ],
   "layers": [
     [
       "KC_ESC",
@@ -28,8 +45,8 @@
       "KC_C",
       "KC_V",
       "KC_B",
-      "KC_NO",
-      "KC_NO",
+      "KC_BSPC",
+      "KC_DEL",
       "KC_TAB",
       "MO(1)",
       "KC_SFTENT",
@@ -58,8 +75,8 @@
       "KC_COMM",
       "KC_M",
       "KC_N",
-      "KC_NO",
-      "KC_NO",
+      "KC_MINS",
+      "KC_EQL",
       "KC_RALT",
       "MO(2)",
       "KC_SPC",
@@ -102,13 +119,13 @@
       "KC_8",
       "KC_7",
       "KC_6",
-      "KC_NO",
+      "S(KC_MINS)",
       "KC_5",
       "KC_4",
       "KC_3",
       "KC_2",
       "KC_1",
-      "KC_NO",
+      "S(KC_EQL)",
       "S(KC_RBRC)",
       "KC_RBRC",
       "KC_LBRC",
@@ -116,8 +133,8 @@
       "KC_NO",
       "KC_NO",
       "S(KC_RBRC)",
-      "KC_NO",
-      "KC_NO",
+      "KC_MINS",
+      "KC_EQL",
       "S(KC_LBRC)",
       "KC_NO",
       "KC_NO",
@@ -128,53 +145,26 @@
       "KC_NO"
     ],
     [
-      "KC_F12",
-      "KC_MS_ACCEL0",
+      "KC_F1",
       "KC_F2",
       "KC_F3",
       "KC_F4",
       "KC_F5",
-      "RGB_TOG",
-      "KC_MS_LEFT",
-      "KC_MS_UP",
-      "KC_MS_DOWN",
-      "KC_MS_RIGHT",
-      "KC_PPLS",
-      "RGB_MOD",
+      "KC_F6",
+      "KC_F7",
+      "KC_F8",
+      "KC_F9",
+      "KC_F10",
+      "KC_F11",
+      "KC_F12",
       "KC_LEFT",
-      "KC_UP",
       "KC_DOWN",
+      "KC_UP",
       "KC_RGHT",
       "KC_EQL",
-      "KC_NO",
-      "KC_NO",
-      "KC_NO",
-      "KC_NO",
-      "S(KC_MINS)",
       "KC_MINS",
-      "KC_NO",
-      "KC_NO",
-      "KC_LGUI",
-      "KC_MS_BTN3",
-      "KC_MS_BTN1",
-      "KC_MS_BTN2",
-      "KC_F11",
-      "KC_F10",
-      "KC_F9",
-      "KC_F8",
-      "KC_F7",
-      "KC_F6",
-      "KC_NO",
-      "KC_NO",
-      "KC_NO",
-      "KC_NO",
-      "KC_NO",
-      "KC_NO",
-      "KC_NO",
-      "KC_NO",
-      "KC_NO",
-      "KC_NO",
-      "KC_NO",
+      "S(KC_MINS)",
+      "S(KC_EQL)",
       "KC_NO",
       "KC_NO",
       "KC_NO",
@@ -186,8 +176,35 @@
       "KC_NO",
       "KC_NO",
       "KC_TRNS",
-      "KC_NO",
-      "KC_NO"
+      "KC_TRNS",
+      "KC_TRNS",
+      "KC_TRNS",
+      "KC_TRNS",
+      "KC_TRNS",
+      "KC_TRNS",
+      "KC_TRNS",
+      "KC_TRNS",
+      "KC_TRNS",
+      "KC_TRNS",
+      "KC_TRNS",
+      "KC_TRNS",
+      "KC_TRNS",
+      "KC_TRNS",
+      "KC_TRNS",
+      "KC_TRNS",
+      "KC_TRNS",
+      "KC_TRNS",
+      "KC_TRNS",
+      "KC_TRNS",
+      "KC_TRNS",
+      "KC_TRNS",
+      "KC_TRNS",
+      "KC_TRNS",
+      "KC_TRNS",
+      "KC_TRNS",
+      "KC_TRNS",
+      "KC_TRNS",
+      "KC_TRNS"
     ],
     [
       "KC_NO",
@@ -254,28 +271,76 @@
   ],
   "encoders": [
     [
-      ["KC_PGUP", "KC_PGDN"],
-      ["KC_MPRV", "KC_MNXT"],
-      ["RGB_RMOD", "RGB_MOD"],
-      ["RGB_SPD", "RGB_SPI"]
+      [
+        "KC_PGUP",
+        "KC_PGDN"
+      ],
+      [
+        "KC_MPRV",
+        "KC_MNXT"
+      ],
+      [
+        "RGB_RMOD",
+        "RGB_MOD"
+      ],
+      [
+        "RGB_SPD",
+        "RGB_SPI"
+      ]
     ],
     [
-      ["KC_VOLD", "KC_VOLU"],
-      ["KC_HOME", "KC_END"],
-      ["RGB_HUD", "RGB_HUI"],
-      ["KC_UP", "KC_DOWN"]
+      [
+        "KC_VOLD",
+        "KC_VOLU"
+      ],
+      [
+        "KC_HOME",
+        "KC_END"
+      ],
+      [
+        "RGB_HUD",
+        "RGB_HUI"
+      ],
+      [
+        "KC_UP",
+        "KC_DOWN"
+      ]
     ],
     [
-      ["KC_VOLD", "KC_VOLU"],
-      ["KC_MPRV", "KC_MNXT"],
-      ["RGB_SAD", "RGB_SAI"],
-      ["KC_LEFT", "KC_RGHT"]
+      [
+        "KC_VOLD",
+        "KC_VOLU"
+      ],
+      [
+        "KC_MPRV",
+        "KC_MNXT"
+      ],
+      [
+        "RGB_SAD",
+        "RGB_SAI"
+      ],
+      [
+        "KC_LEFT",
+        "KC_RGHT"
+      ]
     ],
     [
-      ["KC_PGDN", "KC_PGUP"],
-      ["KC_HOME", "KC_END"],
-      ["RGB_VAD", "RGB_VAI"],
-      ["KC_UP", "KC_DOWN"]
+      [
+        "KC_PGDN",
+        "KC_PGUP"
+      ],
+      [
+        "KC_HOME",
+        "KC_END"
+      ],
+      [
+        "RGB_VAD",
+        "RGB_VAI"
+      ],
+      [
+        "KC_UP",
+        "KC_DOWN"
+      ]
     ]
   ]
 }


### PR DESCRIPTION
## Summary
- tune Iris Rev8 layout for C# productivity
- add minus/equals/backspace/delete to base layer
- expose plus/underscore on the right shift layer
- provide F‑keys and arrow cluster on the left shift layer and clear the right side

## Testing
- `jq '.' current/iris_rev__8.layout.json`

------
https://chatgpt.com/codex/tasks/task_e_68667ee117308328b5317fdbb2fe7bcc